### PR TITLE
feat: add vim mode

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -33,6 +33,7 @@
     "esbuild": "^0.28.0",
     "lucide-react": "^1.7.0",
     "magic-string": "^0.30.21",
+    "monaco-vim": "^0.4.4",
     "nanoid": "^5.1.7",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/apps/desktop/shared/types.ts
+++ b/apps/desktop/shared/types.ts
@@ -37,6 +37,7 @@ export interface UpdateInfo {
 
 /** App settings */
 export type ThemeMode = 'dark' | 'light' | 'system'
+export type LineNumbersMode = 'on' | 'off' | 'relative' | 'interval'
 
 export interface AppSettings {
   // Editor
@@ -44,6 +45,8 @@ export interface AppSettings {
   tabSize: number
   wordWrap: boolean
   minimap: boolean
+  vimMode: boolean
+  lineNumbers: LineNumbersMode
   // Execution
   autoRunEnabled: boolean
   autoRunDelay: number
@@ -57,6 +60,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   tabSize: 2,
   wordWrap: true,
   minimap: false,
+  vimMode: false,
+  lineNumbers: 'on',
   autoRunEnabled: false,
   autoRunDelay: 300,
   executionTimeout: 5,

--- a/apps/desktop/src/components/Editor/EditorPane.tsx
+++ b/apps/desktop/src/components/Editor/EditorPane.tsx
@@ -15,6 +15,8 @@ import { useUIStore } from '../../store/ui'
 import { usePackagesStore } from '../../store/packages'
 import * as bridge from '../../ipc/bridge'
 import type { Monaco } from '@monaco-editor/react'
+import { initVimMode, VimAdapterInstance } from 'monaco-vim'
+import VimStatusBar from './VimStatusBar'
 
 export function EditorPane() {
   const activeTab = useTabsStore((s) => s.activeTab)
@@ -26,19 +28,24 @@ export function EditorPane() {
   const tabSize = useSettingsStore((s) => s.tabSize)
   const wordWrap = useSettingsStore((s) => s.wordWrap)
   const minimap = useSettingsStore((s) => s.minimap)
+  const vimMode = useSettingsStore((s) => s.vimMode)
+  const lineNumbers = useSettingsStore((s) => s.lineNumbers)
   const autoRunEnabled = useSettingsStore((s) => s.autoRunEnabled)
   const autoRunDelay = useSettingsStore((s) => s.autoRunDelay)
   const setSetting = useSettingsStore((s) => s.setSetting)
   const resolvedTheme = useTheme()
   const outputMode = useUIStore((s) => s.outputMode)
+  const settingsOpen = useUIStore((s) => s.settingsOpen)
 
   const packages = usePackagesStore((s) => s.packages)
   const editorRef = useRef<monacoEditor.IStandaloneCodeEditor | null>(null)
   const monacoRef = useRef<Monaco | null>(null)
+  const statusRef = useRef<HTMLDivElement>(null)
   const ignoreScrollRef = useRef(false)
   const typeLibsRef = useRef<Map<string, { dispose: () => void }>>(new Map())
   const typePathsRef = useRef<string[]>([])
   const [editorVersion, setEditorVersion] = useState(0)
+  const [vimAdapter, setVimAdapter] = useState<VimAdapterInstance | null>(null);
 
   useAutoRun(run, autoRunEnabled, autoRunDelay)
   useErrorHighlighting(editorRef)
@@ -141,6 +148,21 @@ export function EditorPane() {
     return unsub
   }, [outputMode])
 
+  // Enable or disable vim mode after settings are updated
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return
+    if (settingsOpen) return
+
+    editor.focus()
+
+    if (vimMode) {
+      setVimAdapter(initVimMode(editor, statusRef.current, VimStatusBar))
+    } else {
+      vimAdapter?.dispose()
+    }
+  }, [editorVersion, settingsOpen])
+
   // Compute per-line visual heights for output alignment (accounts for word wrap)
   useEffect(() => {
     const editor = editorRef.current
@@ -234,7 +256,7 @@ export function EditorPane() {
         </button>
         <SavedBadge />
       </div>
-      <div className="flex-1">
+      <div className="flex-1 min-h-0">
         <Editor
           key={tab.id}
           height="100%"
@@ -244,6 +266,7 @@ export function EditorPane() {
           value={tab.code}
           onChange={(value) => updateCode(value ?? '')}
           options={{
+            lineNumbers,
             fontSize,
             fontFamily: "var(--font-mono)",
             lineHeight: Math.round(fontSize * 1.5),
@@ -262,7 +285,7 @@ export function EditorPane() {
             cursorSmoothCaretAnimation: 'on',
             cursorBlinking: 'smooth',
             quickSuggestions: { other: true, comments: false, strings: true },
-            inlineSuggest:  {
+            inlineSuggest: {
               enabled: true,
             },
             suggest: {
@@ -273,6 +296,18 @@ export function EditorPane() {
           onMount={handleMount}
         />
       </div>
-    </div>
+      {vimMode && (
+        <div
+          className="vim-status-bar"
+          style={{
+            fontSize,
+            height: fontSize * 1.5 + 12,
+            padding: '6px 12px',
+            width: '100%',
+          }}
+          ref={statusRef}
+        ></div>
+      )}
+    </div >
   )
 }

--- a/apps/desktop/src/components/Editor/EditorPane.tsx
+++ b/apps/desktop/src/components/Editor/EditorPane.tsx
@@ -36,6 +36,7 @@ export function EditorPane() {
   const resolvedTheme = useTheme()
   const outputMode = useUIStore((s) => s.outputMode)
   const settingsOpen = useUIStore((s) => s.settingsOpen)
+  const packagesOpen = useUIStore((s) => s.packagesOpen)
 
   const packages = usePackagesStore((s) => s.packages)
   const editorRef = useRef<monacoEditor.IStandaloneCodeEditor | null>(null)
@@ -148,20 +149,25 @@ export function EditorPane() {
     return unsub
   }, [outputMode])
 
-  // Enable or disable vim mode after settings are updated
+  // Enable or disable vim mode
   useEffect(() => {
     const editor = editorRef.current;
     if (!editor) return
-    if (settingsOpen) return
-
-    editor.focus()
 
     if (vimMode) {
       setVimAdapter(initVimMode(editor, statusRef.current, VimStatusBar))
     } else {
       vimAdapter?.dispose()
     }
-  }, [editorVersion, settingsOpen])
+  }, [editorVersion, vimMode])
+
+  // Auto focus
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return
+
+    if (!settingsOpen && !packagesOpen) editor.focus()
+  }, [editorVersion, settingsOpen, packagesOpen])
 
   // Compute per-line visual heights for output alignment (accounts for word wrap)
   useEffect(() => {

--- a/apps/desktop/src/components/Editor/VimStatusBar.tsx
+++ b/apps/desktop/src/components/Editor/VimStatusBar.tsx
@@ -1,0 +1,6 @@
+import { StatusBar } from "monaco-vim";
+
+export default class VimStatusBar extends StatusBar {
+  setMode(): void {
+  }
+}

--- a/apps/desktop/src/components/Settings/SettingsDialog.tsx
+++ b/apps/desktop/src/components/Settings/SettingsDialog.tsx
@@ -3,7 +3,7 @@ import { X, RotateCcw } from 'lucide-react'
 import { useSettingsStore } from '../../store/settings'
 import { useDialogTransition } from '../../hooks/useDialogTransition'
 import { getPackagePaths } from '../../ipc/bridge'
-import type { ThemeMode } from '../../../shared/types'
+import type { LineNumbersMode, ThemeMode } from '../../../shared/types'
 
 interface SettingsDialogProps {
   open: boolean
@@ -82,6 +82,16 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
               onChange={(v) => settings.setSetting('wordWrap', v)} />
             <ToggleRow label="Minimap" checked={settings.minimap}
               onChange={(v) => settings.setSetting('minimap', v)} />
+            <ToggleRow label="Vim Mode" checked={settings.vimMode}
+              onChange={(v) => settings.setSetting('vimMode', v)} />
+            <SelectRow label="Line Numbers" value={settings.lineNumbers}
+              options={[
+                { value: 'on', label: 'On' },
+                { value: 'off', label: 'Off' },
+                { value: 'relative', label: 'Relative' },
+                { value: 'interval', label: 'Interval' }
+              ]}
+              onChange={(v) => settings.setLineNumbers(v as LineNumbersMode)} />
           </Section>
 
           <Section title="Execution">

--- a/apps/desktop/src/hooks/usePersistence.ts
+++ b/apps/desktop/src/hooks/usePersistence.ts
@@ -21,6 +21,8 @@ export function usePersistence() {
   const tabSize = useSettingsStore((s) => s.tabSize)
   const wordWrap = useSettingsStore((s) => s.wordWrap)
   const minimap = useSettingsStore((s) => s.minimap)
+  const vimMode = useSettingsStore((s) => s.vimMode)
+  const lineNumbers = useSettingsStore((s) => s.lineNumbers)
   const autoRunEnabled = useSettingsStore((s) => s.autoRunEnabled)
   const autoRunDelay = useSettingsStore((s) => s.autoRunDelay)
   const executionTimeout = useSettingsStore((s) => s.executionTimeout)
@@ -67,7 +69,7 @@ export function usePersistence() {
 
     settingsTimerRef.current = setTimeout(() => {
       const settings: AppSettings = {
-        fontSize, tabSize, wordWrap, minimap,
+        fontSize, tabSize, wordWrap, minimap, vimMode, lineNumbers,
         autoRunEnabled, autoRunDelay, executionTimeout, theme
       }
       bridge.saveSettings(settings)
@@ -76,5 +78,5 @@ export function usePersistence() {
     return () => {
       if (settingsTimerRef.current) clearTimeout(settingsTimerRef.current)
     }
-  }, [fontSize, tabSize, wordWrap, minimap, autoRunEnabled, autoRunDelay, executionTimeout, theme])
+  }, [fontSize, tabSize, wordWrap, minimap, vimMode, lineNumbers, autoRunEnabled, autoRunDelay, executionTimeout, theme])
 }

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -355,3 +355,10 @@ input[type="range"]::-webkit-slider-thumb {
 input[type="range"]::-webkit-slider-thumb:hover {
   background: var(--accent);
 }
+
+/* ─── Vim Status Bar ─── */
+.vim-status-bar input {
+  border: none;
+  outline: none;
+  background: var(--primary);
+}

--- a/apps/desktop/src/store/settings.ts
+++ b/apps/desktop/src/store/settings.ts
@@ -1,11 +1,12 @@
 import { create } from 'zustand'
-import type { AppSettings, ThemeMode } from '../../shared/types'
+import type { AppSettings, LineNumbersMode, ThemeMode } from '../../shared/types'
 import { DEFAULT_SETTINGS } from '../../shared/types'
 
 interface SettingsState extends AppSettings {
   // Actions
   setSetting: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void
   setTheme: (theme: ThemeMode) => void
+  setLineNumbers: (lineNumbers: LineNumbersMode) => void
   restoreSettings: (settings: AppSettings) => void
   resetToDefaults: () => void
 }
@@ -16,6 +17,8 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   setSetting: (key, value) => set({ [key]: value }),
 
   setTheme: (theme) => set({ theme }),
+
+  setLineNumbers: (lineNumbers) => set({ lineNumbers }),
 
   restoreSettings: (settings) => set({ ...settings }),
 


### PR DESCRIPTION
This PR adds basic support for vim key bindings and allows customisation of line numbers mode (I personally always use relative line numbers when working with vim).

I'm not a frontend developer, so some things may not have been implemented in the most optimal way. Still, it has been well tested.

Enabling and disabling vim mode:

https://github.com/user-attachments/assets/87c34633-089a-43c9-a819-b35460396c77

Vim mode command bar:

https://github.com/user-attachments/assets/76e8fd6d-844e-4140-b1c3-5f55e0ce4602

Switching line number mode:

https://github.com/user-attachments/assets/44609f21-57e0-4237-a0a6-aa6207fabb88