### PR TITLE
fix: adjust instrumentWithAST import

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -8,9 +8,7 @@ directories:
 
 files:
   - out/**/*
-  - "!node_modules/**/*"
-  - node_modules/esbuild/**/*
-  - node_modules/@esbuild/**/*
+  - node_modules/**/*
 
 afterPack: ./scripts/afterPack.cjs
 

--- a/apps/desktop/src/main/executor/instrument.ts
+++ b/apps/desktop/src/main/executor/instrument.ts
@@ -1,3 +1,5 @@
+import { instrumentWithAST } from './instrument-ast'
+
 /** Prefixes that indicate a line is a statement, not an expression */
 const STATEMENT_PREFIXES = [
   'const ', 'let ', 'var ', 'function ', 'function*', 'class ', 'abstract ',
@@ -259,7 +261,6 @@ export function transformImports(line: string): string {
  */
 export function instrumentCode(code: string): string {
   try {
-    const { instrumentWithAST } = require('./instrument-ast') as typeof import('./instrument-ast')
     return instrumentWithAST(code)
   } catch {
     return instrumentWithRegex(code)


### PR DESCRIPTION
Noticed that, at least on my machine, for both local builds and the released versions, `instrumentWithAST` was never running correctly. The code was always falling back to `instrumentWithRegex`, causing several kinds of issues.

## Old behavior

<img width="1264" height="742" alt="image" src="https://github.com/user-attachments/assets/e97e1e0b-64f7-4ca6-aa29-de7eda89a379" />

<img width="1264" height="742" alt="image" src="https://github.com/user-attachments/assets/d9dce0a9-2a39-46da-86f5-7d121259509e" />

## New behavior

<img width="1264" height="742" alt="image" src="https://github.com/user-attachments/assets/7d9fa9cb-4eae-4d52-a5e4-73cff9aff8d2" />

<img width="1264" height="742" alt="image" src="https://github.com/user-attachments/assets/52c7d637-e633-4733-955e-a8740fef8b7d" />
