### PR TITLE
fix: run npm with Node's bin directory on PATH

### DIFF
--- a/apps/desktop/src/main/executor/__tests__/package-manager.test.ts
+++ b/apps/desktop/src/main/executor/__tests__/package-manager.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { delimiter, join } from 'path'
+import { tmpdir } from 'os'
+
+const testRoot = join(tmpdir(), `nodl-package-manager-test-${process.pid}`)
+const userDataDir = join(testRoot, 'user-data')
+const nvmDir = join(testRoot, 'nvm')
+const npmBinDir = join(nvmDir, 'versions', 'node', 'v24.4.0', 'bin')
+const npmPath = join(npmBinDir, 'npm')
+
+// Mock electron before importing package-manager
+vi.mock('electron', () => ({
+  app: { getPath: () => userDataDir }
+}))
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn()
+}))
+
+import { execSync } from 'child_process'
+
+/** Fresh module instance — package-manager memoizes the resolved npm path */
+async function loadPackageManager() {
+  vi.resetModules()
+  return import('../package-manager')
+}
+
+/** Reads the PATH entry of a spawn env, whatever its casing */
+function envPath(env: NodeJS.ProcessEnv | undefined): string | undefined {
+  if (!env) return undefined
+  const key = Object.keys(env).find(k => k.toUpperCase() === 'PATH')
+  return key ? env[key] : undefined
+}
+
+describe('package manager', () => {
+  const originalNvmDir = process.env.NVM_DIR
+  const originalPath = process.env.PATH
+  const systemPath = ['/usr/bin', '/bin', '/usr/sbin', '/sbin'].join(delimiter)
+
+  beforeEach(() => {
+    rmSync(testRoot, { recursive: true, force: true })
+    mkdirSync(npmBinDir, { recursive: true })
+    writeFileSync(npmPath, '#!/usr/bin/env node\n')
+    process.env.NVM_DIR = nvmDir
+    process.env.PATH = systemPath
+
+    vi.mocked(execSync).mockImplementation((command, options) => {
+      const cmd = String(command)
+      const path = envPath((options as { env?: NodeJS.ProcessEnv } | undefined)?.env)
+
+      // Only the nvm npm exists, and its `#!/usr/bin/env node` launcher needs
+      // Node's sibling bin directory on PATH to run at all
+      if (!cmd.startsWith(`"${npmPath}"`)) throw new Error('npm not found')
+      if (!path?.split(delimiter).includes(npmBinDir)) {
+        throw new Error('env: node: No such file or directory')
+      }
+
+      if (cmd.includes(' --version')) return Buffer.from('10.9.0\n')
+
+      const packageJsonPath = join(userDataDir, 'packages', 'package.json')
+      const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
+      packageJson.dependencies = { dotenv: '17.0.0' }
+      writeFileSync(packageJsonPath, JSON.stringify(packageJson))
+      return Buffer.from('')
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    rmSync(testRoot, { recursive: true, force: true })
+    if (originalNvmDir === undefined) delete process.env.NVM_DIR
+    else process.env.NVM_DIR = originalNvmDir
+    if (originalPath === undefined) delete process.env.PATH
+    else process.env.PATH = originalPath
+  })
+
+  function installCallEnv(): NodeJS.ProcessEnv {
+    const call = vi.mocked(execSync).mock.calls.find(([command]) =>
+      String(command).includes(' install --save-exact ')
+    )
+    return (call?.[1] as { env: NodeJS.ProcessEnv }).env
+  }
+
+  it('adds an nvm npm bin directory to PATH before installing a package', async () => {
+    const { installPackage } = await loadPackageManager()
+
+    expect(installPackage('dotenv')).toEqual({ success: true, name: 'dotenv', version: '17.0.0' })
+
+    const path = envPath(installCallEnv())
+    expect(path?.split(delimiter)[0]).toBe(npmBinDir)
+    expect(path?.split(delimiter)).toEqual(expect.arrayContaining(systemPath.split(delimiter)))
+  })
+
+  it('probes candidate npm binaries with the augmented PATH', async () => {
+    const { getPackagePaths } = await loadPackageManager()
+
+    expect(getPackagePaths().npmPath).toBe(npmPath)
+
+    const probeCall = vi.mocked(execSync).mock.calls.find(([command]) =>
+      String(command) === `"${npmPath}" --version`
+    )
+    const path = envPath((probeCall?.[1] as { env?: NodeJS.ProcessEnv } | undefined)?.env)
+    expect(path?.split(delimiter)[0]).toBe(npmBinDir)
+  })
+
+  it('prepends to the existing PATH key regardless of its casing', async () => {
+    delete process.env.PATH
+    process.env.Path = systemPath
+    try {
+      const { installPackage } = await loadPackageManager()
+      expect(installPackage('dotenv').success).toBe(true)
+
+      const env = installCallEnv()
+      const pathKeys = Object.keys(env).filter(k => k.toUpperCase() === 'PATH')
+      expect(pathKeys).toHaveLength(1)
+      expect(env[pathKeys[0]]?.split(delimiter)).toEqual([npmBinDir, ...systemPath.split(delimiter)])
+    } finally {
+      delete process.env.Path
+      process.env.PATH = systemPath
+    }
+  })
+})

--- a/apps/desktop/src/main/executor/package-manager.ts
+++ b/apps/desktop/src/main/executor/package-manager.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process'
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs'
-import { join } from 'path'
+import { delimiter, dirname, isAbsolute, join } from 'path'
 import { homedir } from 'os'
 import { app } from 'electron'
 import type { InstalledPackage, PackageOperationResult, PackageSearchResult, TypeDefInfo } from '../../../shared/types'
@@ -32,16 +32,7 @@ function resolveNpm(): string {
     join(home, 'scoop', 'shims', 'npm.cmd'),
   ]
 
-  for (const bin of candidates) {
-    try {
-      execSync(`"${bin}" --version`, { stdio: 'pipe', timeout: 3000 })
-      return bin
-    } catch {
-      // not available — try next
-    }
-  }
-
-  // Last resort: scan nvm versions (macOS/Linux), newest Node first
+  // Last resort candidates: nvm versions (macOS/Linux), newest Node first
   try {
     const nvmDir = process.env.NVM_DIR ?? join(home, '.nvm')
     const versionsDir = join(nvmDir, 'versions', 'node')
@@ -54,12 +45,21 @@ function resolveNpm(): string {
           return bMaj !== aMaj ? bMaj - aMaj : bMin - aMin
         })
       for (const v of versions) {
-        const npmPath = join(versionsDir, v, 'bin', 'npm')
-        if (existsSync(npmPath)) return npmPath
+        candidates.push(join(versionsDir, v, 'bin', 'npm'))
       }
     }
   } catch {
     // nvm not present
+  }
+
+  for (const bin of candidates) {
+    try {
+      // Probe with the same env the install gets — a shebang launcher fails otherwise
+      execSync(`"${bin}" --version`, { stdio: 'pipe', timeout: 3000, env: getNpmEnv(bin) })
+      return bin
+    } catch {
+      // not available — try next
+    }
   }
 
   throw new Error('npm not found. Install Node.js from https://nodejs.org')
@@ -70,6 +70,24 @@ let _npm: string | null = null
 function getNpm(): string {
   if (!_npm) _npm = resolveNpm()
   return _npm
+}
+
+/**
+ * Packaged macOS apps are launched with a minimal PATH. When npm comes from
+ * nvm, its launcher uses `#!/usr/bin/env node`, so Node's sibling bin
+ * directory must be available to the child process.
+ */
+function getNpmEnv(npm: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, NODE_ENV: '' }
+  if (!isAbsolute(npm)) return env
+
+  // Windows spells the key "Path" — adding a separate "PATH" would leave two keys
+  // and Node keeps only the first, wiping the real search path
+  const pathKey = Object.keys(env).find(k => k.toUpperCase() === 'PATH') ?? 'PATH'
+  const npmBinDir = dirname(npm)
+  const current = env[pathKey]
+  env[pathKey] = current ? `${npmBinDir}${delimiter}${current}` : npmBinDir
+  return env
 }
 
 function ensurePackagesDir(): void {
@@ -100,7 +118,7 @@ export function installPackage(name: string): PackageOperationResult {
       cwd: PACKAGES_DIR,
       stdio: 'pipe',
       timeout: 60000,
-      env: { ...process.env, NODE_ENV: '' }
+      env: getNpmEnv(npm)
     })
 
     // name may be "axios@1.7.9" — extract bare name for lookup
@@ -173,7 +191,8 @@ export function removePackage(name: string): PackageOperationResult {
     execSync(`"${npm}" uninstall ${name}`, {
       cwd: PACKAGES_DIR,
       stdio: 'pipe',
-      timeout: 30000
+      timeout: 30000,
+      env: getNpmEnv(npm)
     })
     return { success: true, name }
   } catch (err: unknown) {


### PR DESCRIPTION
Fixes #5 

  ## Changes

  - New `getNpmEnv(npm)` prepends `dirname(npm)` to `PATH`, applied to `installPackage()` and `removePackage()` (the latter passed no `env` at all).
  - `resolveNpm()` now collects nvm versions as *candidates* instead of returning early on `existsSync`, and the single probe loop runs `npm --version` with that same env. This also fixes Homebrew: `/opt/homebrew/bin/npm` was failing the probe with exit 127 and being silently rejected, so a machine without nvm got "npm not found" outright. It also means the nvm result is actually validated rather than assumed.
  - `getNpmEnv()` updates the existing PATH key case-insensitively. Windows spells it `Path`, and a plain spread of `process.env` keeps that casing, writing a separate `PATH` key would leave two, and Node keeps only the first, wiping the real search path.
  
  ## Tests

  3 new tests in `package-manager.test.ts`. The `execSync` mock models the actual failure: it rejects any command whose env lacks the Node bin directory, with `env: node: No such file or directory`. Each test asserts a branch that fails without this change — PATH prepended for install, the `--version` probe getting the same env, and a single PATH key when the env uses `Path`.
  
  All tests are green

https://www.loom.com/share/45010ec5f4ce436fa5512e5c6c06000d